### PR TITLE
Add missing comma in drum list

### DIFF
--- a/drums.py
+++ b/drums.py
@@ -9,7 +9,7 @@ def get_random_drums():
 
         "Linn 9000",
         "Linn LinnDrum",
-        "Linn LM-1"
+        "Linn LM-1",
 
         "Oberheim DMX",
 


### PR DESCRIPTION
There was a comma missing, causing the bot to output "Drums: Linn LM-1Oberheim DMX"